### PR TITLE
Fix/deprecated calibration lib resolver

### DIFF
--- a/qualibrate_config/cli/config.py
+++ b/qualibrate_config/cli/config.py
@@ -131,12 +131,12 @@ __all__ = ["config_command"]
 )
 @click.option(
     "--calibration-library-folder",
-    "--runner-calibration-library-resolver",
+    "--runner-calibration-library-folder",
     type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
     default=QUALIBRATE_PATH / "calibrations",
     show_default=True,
     cls=DeprecatedOption,
-    deprecated=("--runner-calibration-library-resolver",),
+    deprecated=("--runner-calibration-library-folder",),
     preferred="--calibration-library-folder",
     help="Path to the folder contains calibration nodes and graphs.",
 )

--- a/qualibrate_config/cli/deprecated/deprecated_options_command.py
+++ b/qualibrate_config/cli/deprecated/deprecated_options_command.py
@@ -28,7 +28,6 @@ def make_deprecated_process(
 ) -> Callable[[ParserOption, Any, ParsingState], None]:
     """Construct a closure to the parser option processor"""
     option_instance = option.obj
-    _validate_deprecated_option(option_instance)
     original_process = option.process
     deprecated, preferred = _validate_deprecated_option(option_instance)
 


### PR DESCRIPTION
## Issue
Using deprecated `--runner-calibration-library-resolver` argument write values to 2 fields: calibration library resolver and folder.

### How to reproduce:
```shell
qualibrate-config config --runner-calibration-library-resolver qualibrate.QualibrationLibrary
```
Expected config:
```
qualibrate :
    ...
    calibration_library :
        folder :    ~/.qualibrate/calibrations
        resolver :  qualibrate.QualibrationLibrary
```
Generated config:
```
qualibrate :
    ...
    calibration_library :
        folder :    qualibrate.QualibrationLibrary
        resolver :  qualibrate.QualibrationLibrary
```

## Fixed
Replace deprecated argument with correct one