### PR TITLE
Use private fields for storing deprecated and preferred options for attribute

### DIFF
--- a/qualibrate_config/cli/deprecated/deprecated_option.py
+++ b/qualibrate_config/cli/deprecated/deprecated_option.py
@@ -13,6 +13,10 @@ class DeprecatedOption(click.Option):
         deprecated: Optional[tuple[str]] = None,
         **kwargs: Any,
     ):
-        self.deprecated = deprecated or ()
-        self.preferred = preferred or args[0][-1]
+        self.__deprecated = deprecated or ()
+        self.__preferred = preferred or args[0][-1]
         super().__init__(*args, **kwargs)
+
+    @property
+    def deprecated_preferred(self) -> tuple[tuple[str, ...], str]:
+        return self.__deprecated, self.__preferred

--- a/qualibrate_config/cli/deprecated/deprecated_options_command.py
+++ b/qualibrate_config/cli/deprecated/deprecated_options_command.py
@@ -16,8 +16,7 @@ def _validate_deprecated_option(
     option: CoreOption,
 ) -> tuple[Sequence[str], str]:
     assert isinstance(option, DeprecatedOption)
-    deprecated = option.deprecated
-    preferred = option.preferred
+    deprecated, preferred = option.deprecated_preferred
     msg = "Expected `deprecated` value for `{}`"
     assert deprecated is not None, msg.format(option.name)
     return deprecated, preferred


### PR DESCRIPTION
[QUAL-1357](https://quantum-machines.atlassian.net/browse/QUAL-1357)

`click` 8.2 added `deprecated` option.
Click deprecated can be flag or str only.